### PR TITLE
feat(pod-delete): Updating failure condition for the pod-delete helper pod

### DIFF
--- a/chaoslib/litmus/container_kill/crictl-chaos.yml
+++ b/chaoslib/litmus/container_kill/crictl-chaos.yml
@@ -101,10 +101,6 @@
     msg: "crictl-chaos lib failed, Unable to create as container-killer chaos pod couldn't be scheduled on the {{ app_node }} node"
   when: "pod_running_status is not defined or pod_running_status != 'Running'"
 
-# chaosStartTimeStamp contains the start timestamp
-- name: "[Prepare]: Getting the chaos start timestamp"
-  set_fact: chaosStartTimeStamp="{{lookup('pipe','date \"+%Y-%m-%d %H:%M:%S\"')}}"
-
 - name: "[Wait]: Wait until the container-killer chaos pod is completed"
   shell: >
     kubectl get pods -l name=container-killer-{{ run_id }} --no-headers -n {{ c_ns }}
@@ -116,18 +112,9 @@
   delay: 1
   retries: "{{ c_duration }}"
 
-# chaosCurrentTimeStamp contains the current timestamp
-- name: "[Prepare]: Getting the chaos current timestamp"
-  set_fact: chaosCurrentTimeStamp="{{lookup('pipe','date \"+%Y-%m-%d %H:%M:%S\"')}}"
-
-# chaosDiffTimeStamp contains the difference of current timestamp and start timestamp
-# it will helpful to track the run duration of helper pod
-- set_fact:
-    chaosDiffTimeStamp: "{{ ((chaosCurrentTimeStamp | to_datetime) - (chaosStartTimeStamp | to_datetime)).total_seconds()  }}"
-
 - fail:
     msg: "container-killer chaos pod failed"
-  when: "chaosDiffTimeStamp|int < c_duration|int"
+  when: "result is defined and result.stdout == 'Failed'"  
       
 - block:
 
@@ -146,8 +133,6 @@
     until: "'No resources found' in result.stderr"
     delay: 2
     retries: 90
-
-  when: "chaosDiffTimeStamp|int >= c_duration|int"
 
 - block:
   - debug:

--- a/chaoslib/litmus/pod_delete/pod_failure_by_litmus.yml
+++ b/chaoslib/litmus/pod_delete/pod_failure_by_litmus.yml
@@ -50,10 +50,6 @@
         c_svc_acc: "{{ chaos_service_account.stdout }}"
         pod_delete_image: "{{ lib_image }}"
 
-    # chaosStartTimeStamp contains the start timestamp
-    - name: "[Prepare]: Getting the chaos start timestamp"
-      set_fact: chaosStartTimeStamp="{{lookup('pipe','date \"+%Y-%m-%d %H:%M:%S\"')}}"
-
     - name: "[Prepare]: Create helper pod for pod delete chaos"
       shell: kubectl create -f /tmp/pod-delete-chaos.yml -n {{ c_ns }}
       args:
@@ -75,18 +71,9 @@
       delay: 1
       retries: "{{ c_duration|int + 10 }}"
 
-      # chaosCurrentTimeStamp contains the current timestamp
-    - name: "[Prepare]: Getting the chaos current timestamp"
-      set_fact: chaosCurrentTimeStamp="{{lookup('pipe','date \"+%Y-%m-%d %H:%M:%S\"')}}"
-
-    # chaosDiffTimeStamp contains the difference of current timestamp and start timestamp
-    # it will helpful to track the run duration of helper pod
-    - set_fact:
-        chaosDiffTimeStamp: "{{ ((chaosCurrentTimeStamp | to_datetime) - (chaosStartTimeStamp | to_datetime)).total_seconds()  }}"
-    
     - fail:
         msg: "pod-delete-chaos pod failed"
-      when: "chaosDiffTimeStamp|int < c_duration|int"  
+      when: "result is defined and result.stdout == 'Failed'"  
 
     - block: 
 
@@ -104,8 +91,6 @@
           until: result_status.stdout ==''
           delay: 2
           retries: 90
-
-      when: "chaosDiffTimeStamp|int >= c_duration|int"
 
     - block:
         - debug:

--- a/experiments/generic/container_kill/container_kill_k8s_job.yml
+++ b/experiments/generic/container_kill/container_kill_k8s_job.yml
@@ -27,9 +27,9 @@ spec:
           - name: APP_LABEL
             value: ''
 
-          # LIB_IMAGE can be - gaiaadm/pumba:0.6.5, litmuschaos/container-killer:latest
+          # LIB_IMAGE can be - gaiaadm/pumba:0.6.5, litmuschaos/container-kill-helper:latest
           # For pumba image use : gaiaadm/pumba:0.6.5
-          # For containerd image use : litmuschaos/container-killer:latest
+          # For containerd image use : litmuschaos/container-kill-helper:latest
           - name: LIB_IMAGE  
             value: 'gaiaadm/pumba:0.6.5'
             

--- a/experiments/generic/pod_delete/pod_delete_k8s_job.yml
+++ b/experiments/generic/pod_delete/pod_delete_k8s_job.yml
@@ -55,6 +55,9 @@ spec:
           - name: LIB
             value: ''
 
+          - name: LIB_IMAGE
+            value: 'litmuschaos/pod-delete-helper:latest'
+
           # provide the chaos namespace
           - name: CHAOS_NAMESPACE
             value: ''


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Updating the failure condition for the pod-delete helper pod

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
