### PR TITLE
chore (experiment) Adding vmware vm-poweroff-experiment

### DIFF
--- a/chaoslib/vmware/inject_vm_failure_vm_delete.yml
+++ b/chaoslib/vmware/inject_vm_failure_vm_delete.yml
@@ -1,0 +1,100 @@
+---
+- block:
+    - name: "[Prepare]: Deriving the chaos iterations"
+      set_fact:
+        c_iterations: "{{ (c_duration|int / c_interval|int)|int }}"
+      when: c_iterations is not defined and (c_interval is defined and c_interval|int !=0)
+
+    - name: "[Prepare]: Deriving the chaos interval"
+      set_fact:
+        c_interval: "{{ (c_duration|int / c_iterations|int)|int }}"
+      when: c_interval is not defined and c_iterations is defined
+
+    - name: "[Prepare]: Setting the min chaos count to one"
+      set_fact:
+        c_iterations: 1
+      when: "c_iterations is not defined or c_iterations == '0'"
+
+    - block:
+
+        - debug:
+            msg: "***** Waiting for the ramp interval of {{ ramp_time }}s *****"
+
+        - name: "[Ramp]: Waiting for the specified ramp time before injecting chaos"
+          wait_for: timeout="{{ ramp_time }}"
+
+      when: "ramp_time is defined and ramp_time != ''"
+
+    - block:
+        - name: "[Prepare]: Generate a run id if not passed from the engine/experiment"
+          shell: echo $(mktemp) | cut -d '.' -f 2 | cut -c -6
+          register: rand_string
+
+        - set_fact:
+            run_id: "{{ rand_string.stdout | lower }}"
+      when: "run_id is not defined or run_id == ''"
+
+    - name: Getting the serviceAccountName
+      shell: >
+        kubectl get pod {{ chaos_pod_name }} -n {{ c_ns }} -o
+        custom-columns=:.spec.serviceAccountName --no-headers
+      args:
+        executable: /bin/bash
+      register: chaos_service_account
+
+    - name: "[Prepare]: Set the state of vm to stop"
+      uri:
+        url: https://{{ vcenter_server }}/rest/vcenter/vm/{{ vm_moid1 }}/power/stop
+        force_basic_auth: yes
+        validate_certs: no
+        method: POST
+        headers:
+          Cookie: "{{ login.set_cookie }}"
+      register: result1
+
+    - debug:
+        msg: "VM is powered-off"
+
+    - name: "[TimeOut]: Timeout for 1 minute"
+      pause:
+        minutes: 1
+
+    - name: "[Prepare]: Set the state of vm to start"
+      uri:
+        url: https://{{ vcenter_server }}/rest/vcenter/vm/{{ vm_moid1 }}/power/start
+        force_basic_auth: yes
+        validate_certs: no
+        method: POST
+        headers:
+          Cookie: "{{ login.set_cookie }}"
+      register: result1
+
+    - name: "[Status]: Get the current status of vm"
+      uri:
+        url: https://{{ vcenter_server }}/rest/vcenter/vm/{{ vm_moid1 }}/power/
+        force_basic_auth: yes
+        validate_certs: no
+        headers:
+          Cookie: "{{ login.set_cookie }}"
+      register: result
+      until: "'{{ result.json.value.state }}' ==  'POWERED_ON'"
+      delay: 2
+      retries: 5
+
+    - debug:
+        msg: "The state of vm is {{ result.json.value.state }}"
+
+    - fail:
+        msg: "vm-delete-chaos pod failed"
+      when: "result.json.value.state == 'POWERED_OFF'"
+
+
+    - block:
+        - debug:
+            msg: "***** Waiting for the ramp interval of {{ ramp_time }}s *****"
+
+        - name: "[Ramp]: Waiting for the specified ramp time after injecting chaos"
+          wait_for: timeout="{{ ramp_time }}"
+
+      when: "ramp_time is defined and ramp_time != ''"
+

--- a/chaoslib/vmware/inject_vm_failure_vm_delete.yml
+++ b/chaoslib/vmware/inject_vm_failure_vm_delete.yml
@@ -1,19 +1,5 @@
 ---
 - block:
-    - name: "[Prepare]: Deriving the chaos iterations"
-      set_fact:
-        c_iterations: "{{ (c_duration|int / c_interval|int)|int }}"
-      when: c_iterations is not defined and (c_interval is defined and c_interval|int !=0)
-
-    - name: "[Prepare]: Deriving the chaos interval"
-      set_fact:
-        c_interval: "{{ (c_duration|int / c_iterations|int)|int }}"
-      when: c_interval is not defined and c_iterations is defined
-
-    - name: "[Prepare]: Setting the min chaos count to one"
-      set_fact:
-        c_iterations: 1
-      when: "c_iterations is not defined or c_iterations == '0'"
 
     - block:
 

--- a/experiments/vmware/vm-delete/README.md
+++ b/experiments/vmware/vm-delete/README.md
@@ -1,0 +1,14 @@
+## Experiment Metadata
+
+<table>
+<tr>
+<th> Name </th>
+<th> Description </th>
+<th> Documentation Link </th>
+</tr>
+<tr>
+ <td> vm-delete </td>
+ <td> This experiment stops an vm instance of an application deployment for a certin chaos duration.  </td>
+ <td>  <a href="https://docs.litmuschaos.io/docs/vm-delete/"> Here </a> </td>
+ </tr>
+ </table>

--- a/experiments/vmware/vm-delete/README.md
+++ b/experiments/vmware/vm-delete/README.md
@@ -1,13 +1,5 @@
 ## Experiment Metadata
 
----
-id:vm-delete
-title: VM Delete Experiment Details
-sidebar_label: VM Delete
-------
-
-## Experiment Metadata
-
 <table>
   <tr>
     <th> Type </th>
@@ -142,10 +134,10 @@ subjects:
     <td> Defaults to 30s </td>
   </tr>
   <tr>
-    <th> VCENTERSERVER </th>
-    <th> IP Address of the vcenter </th>
-    <th> Required </th>
-    <th> Should be specified in secret created </th>
+    <td> VCENTERSERVER </td>
+    <td> IP Address of the vcenter </td>
+    <td> Required </td>
+    <td> Should be specified in secret created </td>
   </tr>
   <tr> 
     <td> VCENTERUSER </td>

--- a/experiments/vmware/vm-delete/README.md
+++ b/experiments/vmware/vm-delete/README.md
@@ -1,14 +1,237 @@
 ## Experiment Metadata
 
+---
+id:vm-delete
+title: VM Delete Experiment Details
+sidebar_label: VM Delete
+------
+
+## Experiment Metadata
+
 <table>
-<tr>
-<th> Name </th>
-<th> Description </th>
-<th> Documentation Link </th>
-</tr>
-<tr>
- <td> vm-delete </td>
- <td> This experiment stops an vm instance of an application deployment for a certin chaos duration.  </td>
- <td>  <a href="https://docs.litmuschaos.io/docs/vm-delete/"> Here </a> </td>
- </tr>
- </table>
+  <tr>
+    <th> Type </th>
+    <th> Description  </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> VMWare </td>
+    <td> Stopping a VM for a certain chaos duration</td>
+    <td> EKS </td>
+  </tr>
+</table>
+
+
+## Prerequisites
+
+- Ensure that Kubernetes Version > 1.13
+- Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
+- Ensure that the `vm-delete` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace If not, install from [here](https://hub.litmuschaos.io/api/chaos/master?file=charts/vmware/vm-delete/experiment.yaml)
+- Ensure that you have sufficient Vcenter access to stop and start the vm. 
+- Ensure to create a Kubernetes secret having the Vcenter credentials in the `CHAOS_NAMESPACE`. A sample secret file looks like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vcenter-secret
+  namespace: litmus
+type: Opaque
+stringData:
+    VCENTERSERVER: XXXXXXXXXXX
+    VCENTERUSER: XXXXXXXXXXXXX
+    VCENTERPASS: XXXXXXXXXXXXX
+```
+
+
+## Entry-Criteria
+
+-   vm is healthy before chaos injection.
+
+## Exit-Criteria
+
+-   vm is healthy post chaos injection.
+
+## Details
+
+-   Experiment uses vmware api's to start/stop the vm. 
+-   Stops a VM before bringing it back to running state after the specified chaos duration. 
+-   It helps to check the performance of the application/process running on the vmware server.
+
+
+## Integrations
+
+-   vm-delete can be effected using the chaos library: `litmus`, which makes use of vmware api's to start/stop a vm in vmware environment. 
+-   The desired chaoslib can be selected by setting the above options as value for the env variable `LIB`
+
+## Steps to Execute the Chaos Experiment
+
+- This Chaos Experiment can be triggered by creating a ChaosEngine resource on the cluster. To understand the values to provide in a ChaosEngine specification, refer [Getting Started](getstarted.md/#prepare-chaosengine)
+
+- Follow the steps in the sections below to create the chaosServiceAccount, prepare the ChaosEngine & execute the experiment.
+
+### Prepare chaosServiceAccount
+
+- Use this sample RBAC manifest to create a chaosServiceAccount in the desired (app) namespace. This example consists of the minimum necessary role permissions to execute the experiment.
+
+#### Sample Rbac Manifest
+
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/vmware/vm-delete/rbac.yaml yaml)
+```yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vm-delete-sa
+  namespace: default
+  labels:
+    name: vm-delete-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: vm-delete-sa
+  namespace: default
+  labels:
+    name: vm-delete-sa
+rules: [{'apiGroups': ['', 'batch', 'litmuschaos.io'], 'resources': ['jobs', 'pods', 'deployments','pods/log', 'events', 'chaosengines', 'chaosexperiments', 'chaosresults', 'secrets'], 'verbs': ['create', 'list', 'get', 'update', 'patch', 'delete','deletecollection']}]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: vm-delete-sa
+  namespace: default
+  labels:
+    name: vm-delete-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vm-delete-sa
+subjects:
+- kind: ServiceAccount
+  name: vm-delete-sa
+  namespace: default
+```
+
+### Prepare ChaosEngine
+
+- Provide the application info in `spec.appinfo`
+- Provide the auxiliary applications info (ns & labels) in `spec.auxiliaryAppInfo`
+- Override the experiment tunables if desired in `experiments.spec.components.env`
+- To understand the values to provided in a ChaosEngine specification, refer [ChaosEngine Concepts](chaosengine-concepts.md)
+
+#### Supported Experiment Tunables
+
+<table>
+  <tr>
+    <th> Variables </th>
+    <th> Description </th>
+    <th> Specify In ChaosEngine </th>
+    <th> Notes </th>
+  </tr>
+  <tr> 
+    <td> APP_VM_MOID </td>
+    <td> Moid of the vmware instance</td>
+    <td> Required </td>
+    <td> </td>
+  </tr>
+  <tr> 
+    <td> TOTAL_CHAOS_DURATION </td>
+    <td> The time duration for chaos insertion (sec) </td>
+    <td> Optional </td>
+    <td> Defaults to 30s </td>
+  </tr>
+  <tr>
+    <th> VCENTERSERVER </th>
+    <th> IP Address of the vcenter </th>
+    <th> Required </th>
+    <th> Should be specified in secret created </th>
+  </tr>
+  <tr> 
+    <td> VCENTERUSER </td>
+    <td> Username of Vcenter </td>
+    <td> Required </td>
+    <td> Should be specified in secret created having access to start/stop the vm </td>
+  </tr>
+  <tr> 
+    <td> VCENTERPASS </td>
+    <td> Password of Vcenter </td>
+    <td> Required </td>
+    <td> Should be specified in secret created </td>
+  </tr>
+</table>
+
+#### Sample ChaosEngine Manifest
+
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/vmware/vm-delete/engine.yaml yaml)
+```yaml
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  # It can be true/false
+  annotationCheck: 'false'
+  # It can be active/stop
+  engineState: 'active'
+  #ex. values: ns1:name=percona,ns2:run=nginx
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: vm-delete-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'retain'
+  experiments:
+    - name: vm-delete
+      spec:
+        components:
+          env:
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+
+            # provide the kill count
+            - name: APP_VM_MOID
+              value: ''              
+
+            - name: VCENTERSERVER
+              valueFrom:
+                secretKeyRef:
+                  name: vcenter-secret
+                  key: VCENTERSERVER
+
+            - name: VCENTERUSER
+              valueFrom:
+                secretKeyRef:
+                  name: vcenter-secret
+                  key: VCENTERUSER
+
+            - name: VCENTERPASS
+              valueFrom:
+                secretKeyRef:
+                  name: vcenter-secret
+                  key: VCENTERPASS        
+```
+
+### Create the ChaosEngine Resource
+
+- Create the ChaosEngine manifest prepared in the previous step to trigger the Chaos.
+
+  `kubectl apply -f chaosengine.yml`
+
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
+  section to identify the root cause and fix the issues.
+
+### Watch Chaos progress
+  
+-  You can monitor vcenter console to keep a watch over the vm state.   
+
+### Check Chaos Experiment Result
+
+- Check whether the application is resilient to the vm-delete, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
+
+  `kubectl describe chaosresult nginx-chaos-vm-delete -n <application-namespace>`
+
+### vm-delete Experiment Demo
+
+- A sample recording of this experiment execution will be added soon.

--- a/experiments/vmware/vm-delete/chaosutil.j2
+++ b/experiments/vmware/vm-delete/chaosutil.j2
@@ -1,0 +1,3 @@
+{% if c_lib is defined and c_lib == 'litmus' %}
+c_util: "/chaoslib/vmware/inject_vm_failure_vm_delete.yml"
+{% endif %}

--- a/experiments/vmware/vm-delete/vm-delete.chartserviceversion.yaml
+++ b/experiments/vmware/vm-delete/vm-delete.chartserviceversion.yaml
@@ -1,0 +1,23 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: vm-delete 
+  version: 0.1.0
+  annotations:
+    categories: vmware
+    repository: https://github.com/litmuschaos/litmus-ansible/tree/master/vmware/vm-delete
+    support: https://kubernetes.slack.com/messages/CNXNB0ZTN
+spec:
+  displayName: vm-delete 
+  categoryDescription: >
+    stops a vm for a certain chaos duration 
+  keywords: ['pods', 'kubernetes', 'vmware','vm-delete', 'nginx'] 
+  maturity: alpha 
+  minKubeVersion: 1.12.0 
+  provider: {'name': 'Wipro'}
+  maintainers: ['golkonda.joyneer@wipro.com'] 
+  contributors: ['golkonda.joyneer@wipro.com'] 
+  links: ['https://docs.litmuschaos.io/docs/getstarted/'] 
+  icon:
+    - url: 
+      mediatype: ""

--- a/experiments/vmware/vm-delete/vm-delete_ansible_logic.yml
+++ b/experiments/vmware/vm-delete/vm-delete_ansible_logic.yml
@@ -8,7 +8,6 @@
     a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
     auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"
     c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
-    c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
     c_experiment: "vm-delete" 
     ramp_time: "{{ lookup('env','RAMP_TIME') }}"
     chaos_pod_name: "{{ lookup('env','POD_NAME') }}"

--- a/experiments/vmware/vm-delete/vm-delete_ansible_logic.yml
+++ b/experiments/vmware/vm-delete/vm-delete_ansible_logic.yml
@@ -1,0 +1,131 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    a_kind: "{{ lookup('env','APP_KIND') }}"
+    a_label: "{{ lookup('env','APP_LABEL') }}"
+    a_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+    auxiliary_appinfo: "{{ lookup('env','AUXILIARY_APPINFO') }}"
+    c_duration: "{{ lookup('env','TOTAL_CHAOS_DURATION') }}"
+    c_interval: "{{ lookup('env','CHAOS_INTERVAL') }}"
+    c_experiment: "vm-delete" 
+    ramp_time: "{{ lookup('env','RAMP_TIME') }}"
+    chaos_pod_name: "{{ lookup('env','POD_NAME') }}"
+    c_ns: "{{ lookup('env','CHAOS_NAMESPACE') }}"
+    chaos_uid: "{{ lookup('env','CHAOS_UID') }}"
+    c_engine: "{{ lookup('env','CHAOSENGINE') }}"
+    c_lib: "{{ lookup('env','LIB') }}"
+    vm_moid1: "{{ lookup('env','APP_VM_MOID') }}"
+    ansible_python_interpreter: "/usr/bin/python3"
+    vcenter_server: "{{ lookup('env','VCENTERSERVER') }}"
+    vcenter_user: "{{ lookup('env','VCENTERUSER') }}"
+    vcenter_pass: "{{ lookup('env','VCENTERPASS') }}"  
+
+  tasks:
+    - block:
+            
+        ## DETERMINE THE CHAOSLIB TASKFILES TO BE USED
+        - include: vm_delete_ansible_prerequisites.yml
+
+        - name: "[PreReq]: Including the chaos util for the {{ c_experiment }} experiment"
+          include_vars:
+            file: /tmp/chaosutil.yml
+      
+         ## GENERATE EXP RESULT NAME
+        - name: "[PreReq]: Constructing the chaos result name"
+          set_fact:
+            c_result: "{{ c_engine }}-{{ c_experiment }}"
+          when: "c_engine is defined and c_engine != ''"
+
+        ## RECORD START-OF-EXPERIMENT IN LITMUSCHAOS RESULT CR
+        - name: "[PreReq]: Updating the chaos result of {{ c_experiment }} experiment (SOT)"
+          include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'SOT'
+            namespace: "{{ c_ns }}"
+
+        ## DISPLAY APP INFORMATION 
+        - name: "[Info]: Display the application information passed via the test job"
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "VM_MOID        : {{ vm_moid1 }}"
+              - "Ramp Time    : {{ ramp_time }}"  
+
+        ## GET SESSION IF FOR VMWARE API AUTHENTICATION
+        - name: "[Prereq]: Get the session for vmware api authentication"
+          include_tasks: "/utils/vmware/login.yml"
+
+        ## PRE-CHAOS APPLICATION STATUS CHECK
+        - name: "[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)"
+          include_tasks: "/utils/vmware/get_vm_status.yml"
+          vars:
+            vm: "{{ vm_moid1 }}"
+            delay: 2
+            retries: 10
+
+
+        ## RECORD EVENT FOR PRE-CHAOS CHECK
+        - name: "[Event]: Generating an Event for PreChaosCheck"
+          include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PreChaosCheck"
+            exp_pod_name: "{{ chaos_pod_name }}"
+            engine_ns: "{{ c_ns }}"
+            message: "AUT is Running successfully"
+          when: "c_engine is defined and c_engine != ''"
+
+
+         ## READY TO DELETE THE VM
+        - name: "[Prepare]: Including the vmware vm-delete lib"
+          include_tasks: "{{ c_util }}"
+          vars:
+            app_ns: "{{ a_ns }}"
+            app_label: "{{ a_label }}"
+
+
+        ## POST-CHAOS APPLICATION STATUS CHECK
+        - name: "[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)"
+          include_tasks: "/utils/vmware/get_vm_status.yml"
+          vars:
+            vm: "{{ vm_moid1 }}"
+            delay: 2
+            retries: 5
+
+        ## RECORD EVENT FOR POST-CHAOS CHECK
+        - name: "[Event]: Generating an Event for PostChaosCheck"
+          include_tasks: /utils/common/generate-kubernetes-chaos-events.yml
+          vars:
+            stage: "PostChaosCheck"
+            exp_pod_name: "{{ chaos_pod_name }}"
+            engine_ns: "{{ c_ns }}"
+            message: "AUT is Running successfully"
+          when: "c_engine is defined and c_engine != ''"
+        
+        - set_fact:
+            flag: "Pass"
+
+        - name: "[Result]: Getting the final result of {{ c_experiment }} experiment"
+          debug:
+            msg: " experiment has been {{ flag }}ed"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+        - name: "[Result]: Getting the final result of {{ c_experiment }} experiment"
+          debug:
+            msg: " experiment has been {{ flag }}ed"
+
+      always: 
+
+        ## Getting failure step from experiment-pod
+        - include_tasks: /utils/runtime/getting_failure_step.yml  
+ 
+        ## RECORD END-OF-TEST IN LITMUSCHAOS RESULT CR
+        - name: "[The End]: Updating the chaos result of {{ c_experiment }} experiment (EOT)"
+          include_tasks: /utils/runtime/update_chaos_result_resource.yml
+          vars:
+            status: 'EOT'
+            namespace: "{{ c_ns }}"

--- a/experiments/vmware/vm-delete/vm-delete_k8s_job.yml
+++ b/experiments/vmware/vm-delete/vm-delete_k8s_job.yml
@@ -1,0 +1,78 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: vm-delete-
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: vm-delete
+    spec:
+      # Placeholder that is updated by the executor for automated runs
+      # Provide appropriate SA (with desired permissions) if executed manually
+      serviceAccountName: %CHAOS_SERVICE_ACCOUNT%
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: litmuschaos/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: 'default'
+
+          - name: APP_NAMESPACE
+            value: ''
+
+          - name: APP_LABEL
+            value: ''
+
+          - name: APP_KIND
+            value: '' 
+
+          - name: TOTAL_CHAOS_DURATION
+            value: ''
+
+          # provide vm moid
+          - name: APP_VM_MOID
+            value: ''
+          
+          # provide auxiliary application details - namespace and labels of the applications
+          # sample input is - "ns1:app=percona,ns2:name=nginx"
+          - name: AUXILIARY_APPINFO
+            value: ''
+
+          ## Period to wait before injection of chaos in sec
+          - name: RAMP_TIME
+            value: ''
+
+          - name: VCENTERSERVER
+            value: ''
+
+          - name: VCENTERUSER
+            value: ''
+
+          - name: VCENTERPASS
+            value: ''
+
+          ## env var that describes the library used to execute the chaos
+          ## default: litmus. Supported values: litmus, powerfulseal, chaoskube
+          - name: LIB
+            value: 'litmus'
+
+          # provide the chaos namespace
+          - name: CHAOS_NAMESPACE
+            value: ''
+        
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+          - name: CHAOS_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/vmware/vm-delete/vm-delete-ansible-logic.yml -i /etc/ansible/hosts; exit 0"]

--- a/experiments/vmware/vm-delete/vm_delete_ansible_prerequisites.yml
+++ b/experiments/vmware/vm-delete/vm_delete_ansible_prerequisites.yml
@@ -1,0 +1,4 @@
+- name: "[PreReq] Identify the chaos util for {{ c_experiment }} experiment"
+  template:
+    src: chaosutil.j2
+    dest: /tmp/chaosutil.yml

--- a/utils/vmware/get_vm_status.yml
+++ b/utils/vmware/get_vm_status.yml
@@ -1,0 +1,15 @@
+---
+  - name: Get the status of the vm
+    uri:
+      url: https://{{ vcenter_server }}/rest/vcenter/vm/{{ vm }}/power/
+      force_basic_auth: yes
+      validate_certs: no
+      headers:
+        Cookie: "{{ login.set_cookie }}"
+    register: result
+    until: "'{{ result.json.value.state  }}' ==  'POWERED_ON'"
+    delay: "{{ delay }}"
+    retries: "{{ retries }}"
+
+  - debug:
+      msg: " {{ vm }} is POWERED_ON"

--- a/utils/vmware/login.yml
+++ b/utils/vmware/login.yml
@@ -1,0 +1,10 @@
+---
+  - name: Login into vCenter and get cookies
+    uri:
+      url: https://{{ vcenter_server }}/rest/com/vmware/cis/session
+      force_basic_auth: yes
+      validate_certs: no
+      method: POST
+      user: "{{ vcenter_user }}"
+      password: "{{ vcenter_pass }}"
+    register: login


### PR DESCRIPTION
Signed-off-by: Delphine Joyneer <golkonda.joyneer@wipro.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Adding the new experiment for vmware platform which deletes the VM.



**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
